### PR TITLE
Issue #5: Add a `-p` option for defining the PHP binary to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Each argument allows you to specify which severity should be triggered (`<w|e>`)
 Arguments that can be used multiple times (`-m` and `-c`) can of course use different severities each time. All severities will be aggregated and the highest severity (error > warning) will determine the final state.
 
 ```shell
-Usage: check_php [-s <w|e>] [-u <w|e>] [-m <module> <w|e>] [-b <module> <w|e> [-c <conf> <val> <w|e>] [-v]
+Usage: check_php [-s <w|e>] [-u <w|e>] [-m <module> <w|e>] [-b <module> <w|e> [-c <conf> <val> <w|e>] [-p <path>] [-v]
        check_php -h
        check_php -V
 
@@ -91,6 +91,10 @@ missing modules, misconfigured directives and available updates.
                          nagios warning/error if the configuration does not match.
                          Use multiple times to check against multiple configurations.
                          Example: -c "date.timezone" w -c "Europe/Berlin" e
+
+  -p <path>              [optional] Define the path to the PHP binary that shall be used.  
+                         If no value is given, the current user's default PHP version will be checked.
+                         Example: -p "/usr/bin/php"
 
   -v                     Be verbose (Show PHP Version and Zend Engine Version)
 

--- a/check_php
+++ b/check_php
@@ -254,6 +254,31 @@ check_blacklisted_module() {
 	fi
 }
 
+# Fetch PHP
+# ---------
+# Checks the given arguments for a '-p' option and sets the PHP
+# variable accordingly.
+fetch_php() {
+	while test -n "$1"; do
+		case "$1" in
+			# PHP binary otion.
+			-p)
+				shift
+				PHP="$1"
+
+				# Whether the given PHP binary doesn't exist.
+				if [ ! -x $PHP ]; then
+					echo "PHP binary not found at \"$PHP\" for option \"-p\"."
+					exit $EXIT_UNKNOWN
+				fi
+
+				break
+				;;
+		esac
+		shift
+	done
+}
+
 
 ################################################################################
 #
@@ -276,6 +301,8 @@ elif [ "$1" = "-V" ]; then
 	exit $EXIT_OK
 fi
 
+# Check for PHP binary option
+fetch_php "$@"
 
 # Extended Status Message
 MSG_STARTUP=""
@@ -515,6 +542,14 @@ while test -n "$1"; do
 			print_version
 			exit $EXIT_OK
 			;;
+
+		# ---- PHP binary
+		-p)
+			# The binary option is checked earlier. So just shift
+			# the path and move on.
+			shift
+			;;
+
 		*)
 			printf "Unknown argument: %s\n" "$1"
 			print_usage

--- a/check_php
+++ b/check_php
@@ -82,7 +82,6 @@ print_version() {
 	printf "License: %s\n" "${INFO_LICENSE}"
 }
 
-
 merge_text() {
 	CURR_TEXT="$1"
 	NEXT_TEXT="$2"
@@ -152,11 +151,11 @@ check_version() {
 
 	# Latest available versions
 	if command -v wget >/dev/null 2>&1; then
-		PHP_LATEST="$(wget -qO- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(wget -qO- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u -r)"
 	elif command -v curl >/dev/null 2>&1; then
-		PHP_LATEST="$(curl --silent "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(curl --silent "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u -r)"
 	elif command -v fetch >/dev/null 2>&1; then
-		PHP_LATEST="$(fetch --no-verify-hostname --no-verify-peer --quiet --output=- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(fetch --no-verify-hostname --no-verify-peer --quiet --output=- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u -r)"
 	else
 		echo "[UNKNOW] - check version requires wget, curl or fetch"
 		exit "$EXIT_UNKNOWN"

--- a/check_php
+++ b/check_php
@@ -69,6 +69,8 @@ print_usage() {
 	printf "                         nagios warning/error if the configuration does not match.\n"
 	printf "                         Use multiple times to check against multiple configurations.\n"
 	printf "                         Example: -c \"date.timezone\" w -c \"Europe/Berlin\" e\n\n"
+	printf "  -p <path>              [optional] Define the path to the PHP binary that shall be used.\n"
+	printf "                         If no value is given, the current user's default PHP version will be checked.\n\n"
 	printf "  -v                     Be verbose (Show PHP Version and Zend Engine Version)\n\n"
 	printf "  -h                     Display help\n\n"
 	printf "  -V                     Display version\n"


### PR DESCRIPTION
This pull request adds a -p option that will be evaluated before all other checks occur. This allows defining a PHP version different from the user's default version.

Additionally, the sort order of PHP versions fetched from php.net was reversed for the update check. Otherwise the script would return false results on PHP 5 checks:

```
$ ./check_php -p "/opt/php/5.6/bin/php" -u w
[WARN] PHP 5.6.33 has warnings: Updates available | 'OK'=0;;;0;1 'Errors'=0;1;1;0;1 'Warnings'=1;1;;0;1 'Unknown'=0;;;0;1
[WARNING]  PHP Version 5.6.33 too new. Latest: 5.6.32.
```