### PR TITLE
Issues #2, #5, #7, #8 & #10: Diverse fixes/improvements for the check_php script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ object CheckCommand "php" {
     }
     "-u" = {
       value = "$php_updates$"
-      description = "Check for updated PHP version online. Allowed values are 'w' for warnings and 'e' for critical errors.This check requires wget, curl or fetch."
+      description = "Check for updated PHP version online. Allowed values are 'w' for warnings and 'e' for critical errors. This check requires wget, curl or fetch."
     }
     "-p" = {
       value = "$php_binary$"
@@ -96,6 +96,10 @@ object CheckCommand "php" {
       value = "$php_config$"
       description = "Check PHP setting directives that diverge from the given default value."
       repeat_key = true
+    }
+    "-v" = {
+      set_if = "$php_verbose$"
+      description = "Enable verbose mode."
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,132 @@ check command: check_by_ssh_php
 $ARG1$:        -s e -u w -m curl e -m gettext e -m openssl e -m json e
 ```
 
-## 2. Usage
+## 2. Icinga2 Configuration
+### Command definition
+```
+/* Check PHP health
+ */
+object CheckCommand "php" {
+  import "plugin-check-command"
+
+  command = [ PluginDir + "/check_php" ]
+
+  arguments = {
+    "-s" = {
+      value = "$php_startup$"
+      description = "Check for PHP startup errors and display warning or error if any exists. Allowed values are 'w' for warnings and 'e' for critical errors."
+    }
+    "-u" = {
+      value = "$php_updates$"
+      description = "Check for updated PHP version online. Allowed values are 'w' for warnings and 'e' for critical errors.This check requires wget, curl or fetch."
+    }
+    "-p" = {
+      value = "$php_binary$"
+      description = "Optional path to PHP binary. This argument allows to define a certain PHP binary to be checked. If none is defined, the default PHP version will be used."
+    }
+    "-d" = {
+      value = "$php_delimiter$"
+      description = "Delimiter for multi-value arguments."
+    }
+    "-m" = {
+      value = "$php_modules$"
+      description = "Check for required modules."
+      repeat_key = true
+    }
+    "-b" = {
+      value = "$php_blacklist$"
+      description = "Check for blacklisted modules."
+      repeat_key = true
+    }
+    "-c" = {
+      value = "$php_config$"
+      description = "Check PHP setting directives that diverge from the given default value."
+      repeat_key = true
+    }
+  }
+}
+```
+
+### Service definition example (using apply)
+```
+/* PHP Health
+ */
+apply Service "php-" for (php => config in host.vars.php) {
+  check_command = "php"
+  // Assuming your PHP setup doesn't change too often, we don't
+  // bother to check twice a day only.
+  check_interval = 12h
+
+  display_name = "PHP " + php
+  notes = "Checks currently installed PHP " + php + " health."
+
+  // Service variables from php definition.
+  vars += config
+  vars.php_delimiter = "|"
+  if ( config.php_modules ) {
+    vars.php_modules = []
+    for (key => value in config.php_modules) {
+      vars.php_modules += [ key + vars.php_delimiter + value ]
+    }
+  }
+  if ( config.php_blacklist ) {
+    vars.php_blacklist = []
+    for (key => value in config.php_blacklist) {
+      vars.php_blacklist += [ key + vars.php_delimiter + value ]
+    }
+  }
+  if ( config.php_config ) {
+    vars.php_config = []
+    for (key => value in config.php_config) {
+      vars.php_config += [ key + vars.php_delimiter + value.default + vars.php_delimiter + value.severity ]
+    }
+  }
+
+  // Application rules.
+  assign where host.name = NodeName && host.vars.php
+}
+```
+
+### Host object definition
+```
+object Host "node.example.com" {
+
+  // Other settings.
+
+  vars.php[ "7.1" ] = {
+    php_binary = "/opt/php/7.1/bin/php"
+    php_updates = "w"
+    php_startup = "e"
+    php_modules = {
+      intl = "w"
+      mbstring = "w"
+      soap = "w"
+      apcu = "w"
+      memcached = "w"
+      geoip = "w"
+      mongodb = "w"
+      imagick = "w"
+      redis = "w"
+      openssl = "w"
+      xml = "w"
+      json = "w"
+      curl = "w"
+    }
+    php_blacklist = {
+      mcrypt = "w"
+    }
+    php_config = {
+      "date.timezone" = {
+        default = "Europe/Berlin"
+        severity = "w"
+      }
+    }
+  }
+
+}
+```
+
+## 3. Usage
 
 Each argument allows you to specify which severity should be triggered (`<w|e>`), where `w` triggers a warning and `e` triggers an error.
 Arguments that can be used multiple times (`-m` and `-c`) can of course use different severities each time. All severities will be aggregated and the highest severity (error > warning) will determine the final state.
@@ -108,7 +233,7 @@ missing modules, misconfigured directives and available updates.
 ```
 
 
-## 3. Examples
+## 4. Examples
 
 Checking against prefered timezone and compiled module `mysql`
 
@@ -176,10 +301,10 @@ PHP 5.6.14
 Zend Engine v2.6.0
 ```
 
-## 4. License
+## 5. License
 [![license](https://poser.pugx.org/cytopia/check_php/license)](http://opensource.org/licenses/mit)
 
-## 5. Awesome
+## 6. Awesome
 
 Added by the following [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) lists:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Each argument allows you to specify which severity should be triggered (`<w|e>`)
 Arguments that can be used multiple times (`-m` and `-c`) can of course use different severities each time. All severities will be aggregated and the highest severity (error > warning) will determine the final state.
 
 ```shell
-Usage: check_php [-s <w|e>] [-u <w|e>] [-m <module> <w|e>] [-b <module> <w|e> [-c <conf> <val> <w|e>] [-v]
+Usage: check_php [-s <w|e>] [-u <w|e>] [-m <module> <w|e>] [-b <module> <w|e> [-c <conf> <val> <w|e>] [-p <path>] [-v]
        check_php -h
        check_php -V
 
@@ -90,7 +90,11 @@ missing modules, misconfigured directives and available updates.
   -c <conf> <val> <w|e>  [multiple] Check for misconfigured directives in php.ini and display
                          nagios warning/error if the configuration does not match.
                          Use multiple times to check against multiple configurations.
-                         Example: -c "date.timezone" w -c "Europe/Berlin" e
+                         Example: -c "date.timezone" "Europe/Berlin" e
+
+  -p <path>              [optional] Define the path to the PHP binary that shall be used.  
+                         If no value is given, the current user's default PHP version will be checked.
+                         Example: -p "/usr/bin/php"
 
   -v                     Be verbose (Show PHP Version and Zend Engine Version)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Each argument allows you to specify which severity should be triggered (`<w|e>`)
 Arguments that can be used multiple times (`-m` and `-c`) can of course use different severities each time. All severities will be aggregated and the highest severity (error > warning) will determine the final state.
 
 ```shell
-Usage: check_php [-s <w|e>] [-u <w|e>] [-m <module> <w|e>] [-b <module> <w|e> [-c <conf> <val> <w|e>] [-p <path>] [-v]
+Usage: check_php [-s <w|e>] [-u <w|e>] [-m <module> <w|e>] [-b <module> <w|e> [-c <conf> <val> <w|e>] [-p <path>] [-d <delimiter>] [-v]
        check_php -h
        check_php -V
 
@@ -95,6 +95,10 @@ missing modules, misconfigured directives and available updates.
   -p <path>              [optional] Define the path to the PHP binary that shall be used.  
                          If no value is given, the current user's default PHP version will be checked.
                          Example: -p "/usr/bin/php"
+
+  -d <delimiter>         [optional] Delimiter used to concatenate arguments of the abobe options
+                         that require multiple values.
+                         Example: -d "|" -m "mysql|w" -b "mcrypt|w" -c "date.timezone|Europe/Berlin|e"
 
   -v                     Be verbose (Show PHP Version and Zend Engine Version)
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ missing modules, misconfigured directives and available updates.
                          If no value is given, the current user's default PHP version will be checked.
                          Example: -p "/usr/bin/php"
 
-  -d <delimiter>         [optional] Delimiter used to concatenate arguments of the abobe options
+  -d <delimiter>         [optional] Delimiter used to concatenate arguments of the above options
                          that require multiple values.
                          Example: -d "|" -m "mysql|w" -b "mcrypt|w" -c "date.timezone|Europe/Berlin|e"
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ apply Service "php-" for (php => config in host.vars.php) {
   if ( config.php_config ) {
     vars.php_config = []
     for (key => value in config.php_config) {
-      vars.php_config += [ key + vars.php_delimiter + value.default + vars.php_delimiter + value.severity ]
+      vars.php_config += [ key + vars.php_delimiter + value["default"] + vars.php_delimiter + value["severity"] ]
     }
   }
 
@@ -175,8 +175,8 @@ object Host "node.example.com" {
     }
     php_config = {
       "date.timezone" = {
-        default = "Europe/Berlin"
-        severity = "w"
+        "default" = "Europe/Berlin"
+        "severity" = "w"
       }
     }
   }

--- a/check_php
+++ b/check_php
@@ -69,6 +69,8 @@ print_usage() {
 	printf "                         nagios warning/error if the configuration does not match.\n"
 	printf "                         Use multiple times to check against multiple configurations.\n"
 	printf "                         Example: -c \"date.timezone\" w -c \"Europe/Berlin\" e\n\n"
+	printf "  -p <path>              [optional] Define the path to the PHP binary that shall be used.\n"
+	printf "                         If no value is given, the current user's default PHP version will be checked.\n\n"
 	printf "  -v                     Be verbose (Show PHP Version and Zend Engine Version)\n\n"
 	printf "  -h                     Display help\n\n"
 	printf "  -V                     Display version\n"
@@ -79,7 +81,6 @@ print_version() {
 	printf "Author:  %s (%s)\n" "${INFO_AUTHOR}" "${INFO_GPGKEY}"
 	printf "License: %s\n" "${INFO_LICENSE}"
 }
-
 
 merge_text() {
 	CURR_TEXT="$1"
@@ -254,6 +255,31 @@ check_blacklisted_module() {
 	fi
 }
 
+# Fetch PHP
+# ---------
+# Checks the given arguments for a '-p' option and sets the PHP
+# variable accordingly.
+fetch_php() {
+	while test -n "$1"; do
+		case "$1" in
+			# PHP binary otion.
+			-p)
+				shift
+				PHP="$1"
+
+				# Whether the given PHP binary doesn't exist.
+				if [ ! -x $PHP ]; then
+					echo "PHP binary not found at \"$PHP\" for option \"-p\"."
+					exit $EXIT_UNKNOWN
+				fi
+
+				break
+				;;
+		esac
+		shift
+	done
+}
+
 
 ################################################################################
 #
@@ -276,6 +302,8 @@ elif [ "$1" = "-V" ]; then
 	exit $EXIT_OK
 fi
 
+# Check for PHP binary option
+fetch_php "$@"
 
 # Extended Status Message
 MSG_STARTUP=""
@@ -392,7 +420,7 @@ while test -n "$1"; do
 
 			# Check valid exit code
 			if [ "$SEVERITY" != "w" ] && [ "$SEVERITY" != "e" ]; then
-				echo "Invalid value \"$SEVERITY\" for option \"-m\"."
+				echo "Invalid severity value \"$SEVERITY\" for option \"-m\" and module \"$MODULE\"."
 				exit $EXIT_UNKNOWN
 			fi
 
@@ -432,9 +460,10 @@ while test -n "$1"; do
 
 			# Check valid exit code
 			if [ "$SEVERITY" != "w" ] && [ "$SEVERITY" != "e" ]; then
-				echo "Invalid value \"$SEVERITY\" for option \"-b\"."
+				echo "Invalid severity \"$SEVERITY\" for option \"-b\" and module \"$MODULE\"."
 				exit $EXIT_UNKNOWN
 			fi
+
 
 			# Execute Command
 			TMP_TEXT="$(check_blacklisted_module "$MODULE")"
@@ -477,7 +506,7 @@ while test -n "$1"; do
 
 			# Check valid exit code
 			if [ "$SEVERITY" != "w" ] && [ "$SEVERITY" != "e" ]; then
-				echo "Invalid value \"$SEVERITY\" for option \"-c\"."
+				echo "Invalid severity \"$SEVERITY\" for option \"-c\" and directive \"$CONFIG\"."
 				exit $EXIT_UNKNOWN
 			fi
 
@@ -505,7 +534,7 @@ while test -n "$1"; do
 			CNT_ALL=$((CNT_ALL+1))
 			;;
 
-		# ---- Be versbose
+		# ---- Be verbose
 		-v)
 			CMD="$PHP -v 2>/dev/null | grep -E '(^PHP)|(^Zend)' | awk -F'[,]' '{print \$1}' | awk -F'[(]' '{print \$1}' | awk -F'[-]' '{print \$1}'"
 			MSG_VERBOSE="$(eval "$CMD")"
@@ -515,6 +544,14 @@ while test -n "$1"; do
 			print_version
 			exit $EXIT_OK
 			;;
+
+		# ---- PHP binary
+		-p)
+			# The binary option is checked earlier. So just shift
+			# the path and move on.
+			shift
+			;;
+
 		*)
 			printf "Unknown argument: %s\n" "$1"
 			print_usage

--- a/check_php
+++ b/check_php
@@ -151,11 +151,11 @@ check_version() {
 
 	# Latest available versions
 	if command -v wget >/dev/null 2>&1; then
-		PHP_LATEST="$(wget -qO- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(wget -qO- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -t. -n -k1,1 -k2,2 -k3,3 -u -r)"
 	elif command -v curl >/dev/null 2>&1; then
-		PHP_LATEST="$(curl --silent "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(curl --silent "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -t. -n -k1,1 -k2,2 -k3,3 -u -r)"
 	elif command -v fetch >/dev/null 2>&1; then
-		PHP_LATEST="$(fetch --no-verify-hostname --no-verify-peer --quiet --output=- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(fetch --no-verify-hostname --no-verify-peer --quiet --output=- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -t. -n -k1,1 -k2,2 -k3,3 -u -r)"
 	else
 		echo "[UNKNOW] - check version requires wget, curl or fetch"
 		exit "$EXIT_UNKNOWN"

--- a/check_php
+++ b/check_php
@@ -271,7 +271,7 @@ fetch_php() {
 				PHP="$1"
 
 				# Whether the given PHP binary doesn't exist.
-				if [ ! -x $PHP ]; then
+				if [ ! -x "$PHP" ]; then
 					echo "PHP binary not found at \"$PHP\" for option \"-p\"."
 					exit $EXIT_UNKNOWN
 				fi

--- a/check_php
+++ b/check_php
@@ -71,7 +71,7 @@ print_usage() {
 	printf "                         Example: -c \"date.timezone\" w -c \"Europe/Berlin\" e\n\n"
 	printf "  -p <path>              [optional] Define the path to the PHP binary that shall be used.\n"
 	printf "                         If no value is given, the current user's default PHP version will be checked.\n\n"
-	printf "  -d <delimiter>         [optional] Delimiter used to concatenate arguments of the abobe options\n"
+	printf "  -d <delimiter>         [optional] Delimiter used to concatenate arguments of the above options\n"
 	printf "                         that require multiple values.\n"
 	printf "                         Example: -d \"|\" -m \"mysqli|w\" -b \"mcrypt|w\" -c \"date.timezone|Europe/Berlin|e\"\n\n"
 	printf "  -v                     Be verbose (Show PHP Version and Zend Engine Version)\n\n"

--- a/check_php
+++ b/check_php
@@ -151,11 +151,11 @@ check_version() {
 
 	# Latest available versions
 	if command -v wget >/dev/null 2>&1; then
-		PHP_LATEST="$(wget -qO- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(wget -qO- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
 	elif command -v curl >/dev/null 2>&1; then
-		PHP_LATEST="$(curl --silent "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(curl --silent "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
 	elif command -v fetch >/dev/null 2>&1; then
-		PHP_LATEST="$(fetch --no-verify-hostname --no-verify-peer --quiet --output=- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
+		PHP_LATEST="$(fetch --no-verify-hostname --no-verify-peer --quiet --output=- "https://secure.php.net/releases/index.php?json&version=${PHP_MAJOR}&max=100" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u)"
 	else
 		echo "[UNKNOW] - check version requires wget, curl or fetch"
 		exit "$EXIT_UNKNOWN"

--- a/check_php
+++ b/check_php
@@ -45,7 +45,7 @@ PHP="$(which php)"
 ############################################################
 
 print_usage() {
-	printf "Usage: %s [-s <w|e>] [-u <w|e>] [-m <module> <w|e>] [-b <module> <w|e> [-c <conf> <val> <w|e>] [-v]\n" "${INFO_NAME}"
+	printf "Usage: %s [-s <w|e>] [-u <w|e>] [-m <module> <w|e>] [-b <module> <w|e> [-c <conf> <val> <w|e>] [ -p <path> ] [ -d <delimiter> ] [-v]\n" "${INFO_NAME}"
 	printf "       %s -h\n" "${INFO_NAME}"
 	printf "       %s -V\n\n" "${INFO_NAME}"
 	printf "Nagios plugin that will check if PHP exists, for PHP startup errors,\n"
@@ -71,6 +71,9 @@ print_usage() {
 	printf "                         Example: -c \"date.timezone\" w -c \"Europe/Berlin\" e\n\n"
 	printf "  -p <path>              [optional] Define the path to the PHP binary that shall be used.\n"
 	printf "                         If no value is given, the current user's default PHP version will be checked.\n\n"
+	printf "  -d <delimiter>         [optional] Delimiter used to concatenate arguments of the abobe options\n"
+	printf "                         that require multiple values.\n"
+	printf "                         Example: -d \"|\" -m \"mysqli|w\" -b \"mcrypt|w\" -c \"date.timezone|Europe/Berlin|e\"\n\n"
 	printf "  -v                     Be verbose (Show PHP Version and Zend Engine Version)\n\n"
 	printf "  -h                     Display help\n\n"
 	printf "  -V                     Display version\n"
@@ -280,6 +283,24 @@ fetch_php() {
 	done
 }
 
+# Get delimiter
+# -------------
+# Checks the given arguments for a '-d' option and sets the DELIMITER
+# variable accordingly.
+get_delimiter() {
+	while test -n "$1"; do
+		case "$1" in
+			# Delimiter.
+			-d)
+				shift
+				DELIMITER="$1"
+
+				break
+				;;
+		esac
+		shift
+	done
+}
 
 ################################################################################
 #
@@ -304,6 +325,10 @@ fi
 
 # Check for PHP binary option
 fetch_php "$@"
+
+# Check for delimiter
+DELIMITER=""
+get_delimiter "$@"
 
 # Extended Status Message
 MSG_STARTUP=""
@@ -414,9 +439,14 @@ while test -n "$1"; do
 			shift
 			MODULE="$1"
 
-			# Get next arg in list (Exit code)
-			shift
-			SEVERITY="$1"
+			if [ -z "$DELIMITER" ]; then
+				# Get next arg in list (Exit code)
+				shift
+				SEVERITY="$1"
+			else
+				MODULE=$(echo "$1" | awk -F"$DELIMITER" '{print $1}')
+				SEVERITY=$(echo "$1" | awk -F"$DELIMITER" '{print $2}')
+			fi
 
 			# Check valid exit code
 			if [ "$SEVERITY" != "w" ] && [ "$SEVERITY" != "e" ]; then
@@ -454,9 +484,14 @@ while test -n "$1"; do
 			shift
 			MODULE="$1"
 
-			# Get next arg in list (Exit code)
-			shift
-			SEVERITY="$1"
+			if [ -z "$DELIMITER" ]; then
+				# Get next arg in list (Exit code)
+				shift
+				SEVERITY="$1"
+			else
+				MODULE=$(echo "$1" | awk -F"$DELIMITER" '{print $1}')
+				SEVERITY=$(echo "$1" | awk -F"$DELIMITER" '{print $2}')
+			fi
 
 			# Check valid exit code
 			if [ "$SEVERITY" != "w" ] && [ "$SEVERITY" != "e" ]; then
@@ -496,13 +531,19 @@ while test -n "$1"; do
 			shift
 			CONFIG="$1"
 
-			# Get next arg in list (Config value)
-			shift
-			VALUE="$1"
+			if [ -z "$DELIMITER" ]; then
+				# Get next arg in list (Config value)
+				shift
+				VALUE="$1"
 
-			# Get next arg in list (Exit code)
-			shift
-			SEVERITY="$1"
+				# Get next arg in list (Exit code)
+				shift
+				SEVERITY="$1"
+			else
+				CONFIG=$(echo "$1" | awk -F"$DELIMITER" '{print $1}')
+				VALUE=$(echo "$1" | awk -F"$DELIMITER" '{print $2}')
+				SEVERITY=$(echo "$1" | awk -F"$DELIMITER" '{print $3}')
+			fi
 
 			# Check valid exit code
 			if [ "$SEVERITY" != "w" ] && [ "$SEVERITY" != "e" ]; then
@@ -549,6 +590,13 @@ while test -n "$1"; do
 		-p)
 			# The binary option is checked earlier. So just shift
 			# the path and move on.
+			shift
+			;;
+
+		# ---- With delimiter
+		-d)
+			# The delimiter option is checked earlier. So just shift
+			# the delimiter and move on.
 			shift
 			;;
 


### PR DESCRIPTION
We had to fix some issues with the check_php script in order to making it useful within our Icinga2 installation. This PR includes all of these changes:

- Issue #5: We now allow for defining a PHP binary to be specified using a `-p` command line option.
- Issue #7: The number of fetched releases on update checks was `2`, which was even too less to check PHP 7.0 updates, when PHP 7.1 and 7.2 had updates as well. We increased the value to `100` (to also have some legacy versions listed in case there are really critical security fixes to them).
- Issue #8: Having 100 releases within the 5.x history revealed, that the sorting of versions did not work natively. We changed the sorting to keyed numbered sort and reversed the order to fix false warnings while doing update checks.
- Issue #10: We added a 'delimiter' option `-d` that allows to concatenate argument values. This was necessary to ease Icinga2 integration of the script using the check command plugin without having to create dirty workarounds or custom functions.
- Issue #2: Finally, we added some Icinga2 configuration examples (inspired by our setup) to the README.md.